### PR TITLE
Create form to add a new cohort

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "eslintConfig": {
     "extends": "airbnb",
     "rules": {
-      "react/jsx-filename-extension": "off"
+      "react/jsx-filename-extension": "off",
+      "react/prop-types": "off"
     },
     "env": {
       "browser": true,

--- a/src/components/AppViews.js
+++ b/src/components/AppViews.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Route, withRouter } from 'react-router-dom';
 import Auth from './auth/Auth';
 import Vote from './vote/Vote';
+import AdminViews from './admin/AdminViews';
 
 /* eslint-disable */
 class AppViews extends Component {
@@ -14,6 +15,9 @@ class AppViews extends Component {
         }} />
         <Route exact path="/vote" render={(props) => {
           return <Vote {...props} />
+        }} />
+        <Route path="/admin" render={(props) => {
+          return <AdminViews {...props} />
         }} />
       </React.Fragment>
     )

--- a/src/components/admin/AdminViews.js
+++ b/src/components/admin/AdminViews.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import CohortAdd from './CohortAdd';
+
+const AdminViews = () => (
+  <>
+    <Route
+      exact
+      path="/admin"
+      render={() => <Redirect to="/admin/cohorts/new" />}
+    />
+    <Route
+      exact
+      path="/admin/cohorts/new"
+      component={CohortAdd}
+    />
+  </>
+);
+
+export default AdminViews;

--- a/src/components/admin/CohortAdd.js
+++ b/src/components/admin/CohortAdd.js
@@ -1,14 +1,145 @@
 import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
+import {
+  Form,
+  Dropdown,
+  Container,
+  Grid,
+  GridRow,
+  GridColumn,
+  Header,
+  Button,
+} from 'semantic-ui-react';
+import * as firebase from 'firebase/app';
+import 'firebase/firestore';
+
+const programOptions = [
+  {
+    key: 'day',
+    text: 'Day',
+    value: 'D',
+  },
+  {
+    key: 'evening',
+    text: 'Evening',
+    value: 'E',
+  },
+];
 
 class CohortAdd extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = { program: 'D' };
+    this.db = firebase.firestore();
+
+    this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleProgramChange = this.handleProgramChange.bind(this);
+    this.submit = this.submit.bind(this);
+  }
+
+  handleInputChange(event) {
+    const { name, value } = event.target;
+    this.setState({
+      [name]: value,
+    });
+  }
+
+  handleProgramChange(_e, { value }) {
+    this.setState({ program: value });
+  }
+
+  submit() {
+    const { history } = this.props;
+    const {
+      program,
+      cohortNumber,
+      slackChannel,
+      icon,
+    } = this.state;
+
+    const id = program + cohortNumber;
+    const dayOrEvening = program === 'D' ? 'Day' : 'Evening';
+    const name = `${dayOrEvening} Cohort ${cohortNumber}`;
+    // remove any # signs from slack channel
+    const payload = {
+      icon,
+      name,
+      slackChannel: slackChannel.replace(/#/g, ''),
+    };
+
+    this.db.collection('cohorts').doc(id)
+      .set(payload)
+      .then(() => history.push('/'));
   }
 
   render() {
-    return <p>Hello</p>;
+    const { program } = this.state;
+    return (
+      <Container>
+        <Header
+          as="h1"
+          textAlign="center"
+          content="Add Cohort"
+        />
+        <Grid>
+          <GridRow centered>
+            <GridColumn
+              largeScreen={10}
+              computer={10}
+              tablet={14}
+              mobile={16}
+            >
+              <Form onSubmit={this.submit}>
+                <Form.Group widths="equal">
+                  <Form.Field
+                    name="program"
+                    label="Program"
+                    control={() => (
+                      <Dropdown
+                        placeholder="Select"
+                        fluid
+                        selection
+                        onChange={this.handleProgramChange}
+                        value={program}
+                        options={programOptions}
+                      />
+                    )}
+                  />
+                  <Form.Field
+                    name="cohortNumber"
+                    control="input"
+                    type="number"
+                    placeholder="32"
+                    onChange={this.handleInputChange}
+                    label="Cohort Number"
+                  />
+                  <Form.Field
+                    name="slackChannel"
+                    control="input"
+                    placeholder="day-cohort-32"
+                    onChange={this.handleInputChange}
+                    label="Slack Channel"
+                  />
+                </Form.Group>
+                <Form.Field
+                  name="icon"
+                  control="input"
+                  placeholder="https://avatars2.githubusercontent.com/..."
+                  onChange={this.handleInputChange}
+                  label="Github Image URL"
+                />
+                <Button
+                  type="submit"
+                  content="Submit"
+                  color="orange"
+                />
+              </Form>
+            </GridColumn>
+          </GridRow>
+        </Grid>
+      </Container>
+    );
   }
 }
 
-export default CohortAdd;
+export default withRouter(CohortAdd);

--- a/src/components/admin/CohortAdd.js
+++ b/src/components/admin/CohortAdd.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+
+class CohortAdd extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return <p>Hello</p>;
+  }
+}
+
+export default CohortAdd;


### PR DESCRIPTION
This includes a form to add a new cohort to the ProGrammys database. To test, go to the `/admin` route and add a cohort that's not already in the database. Once you submit the form you should be able to see it populated in the firestore database. I also removed one of the eslint rules that enforced proptypes. I'm happy to put it back in if you want, but that's one rule that could slow us down a bit

#### TODOs
@BryanNilsen 
- I did no styling on this, so hopefully you can clean up after my mess
- I'll leave it up to you whether or not you want to add some form validation to this. The only thing that's in there that's close is I remove any `#` characters from the slack channel input value on submit
- Once auth is in place, we'll want to make this route accessible to only instructors. Anyone else should be taken to a 404 page