### PR TITLE
Auth flow local storage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,56 +1,28 @@
 import React, { Component } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import * as firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
-
-import './App.css';
+import { getUser } from './modules/userManager';
 import AppViews from './components/AppViews';
-
+import './App.css';
 
 class App extends Component {
   constructor() {
     super();
     this.state = {
-      currentUser: null,
-      userLoaded: false,
+      currentUser: getUser(),
     };
-
-    this.db = firebase.firestore();
-
-    firebase.auth().onAuthStateChanged((user) => {
-      if (!user) {
-        this.setState({
-          currentUser: null,
-          userLoaded: true,
-        });
-        return;
-      }
-      this.db.collection('users')
-        .doc(user.uid)
-        .get()
-        .then((userSnapshot) => {
-          const userData = userSnapshot.data();
-          userData.id = userSnapshot.id;
-          this.setState({
-            currentUser: userData,
-            userLoaded: true,
-          });
-        });
-    });
   }
 
   render() {
-    const { currentUser, userLoaded } = this.state;
+    const { currentUser } = this.state;
     return (
       <Router>
         <div className="App">
-          {userLoaded ? (
-            <>
-              <AppViews currentUser={currentUser} />
-            </>
-          ) : null
-          }
+          <AppViews
+            currentUser={currentUser}
+            setCurrentUser={user => this.setState({ currentUser: user })}
+          />
         </div>
       </Router>
     );

--- a/src/components/AppViews.js
+++ b/src/components/AppViews.js
@@ -8,10 +8,12 @@ import AdminViews from './admin/AdminViews';
 class AppViews extends Component {
 
   render() {
+    const { setCurrentUser } = this.props;
+
     return (
       <React.Fragment>
         <Route exact path="/" render={(props) => {
-          return <Auth {...props} />
+          return <Auth {...props} setCurrentUser={setCurrentUser} />
         }} />
         <Route path="/vote/" render={(props) => {
           return <Vote currentUser={this.props.currentUser} {...props} />

--- a/src/components/AppViews.js
+++ b/src/components/AppViews.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Route, withRouter } from 'react-router-dom';
+import { Route, withRouter, Redirect } from 'react-router-dom';
 import Auth from './auth/Auth';
 import Vote from './vote/Vote';
 import AdminViews from './admin/AdminViews';
@@ -8,15 +8,26 @@ import AdminViews from './admin/AdminViews';
 class AppViews extends Component {
 
   render() {
-    const { setCurrentUser } = this.props;
+    const { setCurrentUser, currentUser } = this.props;
 
     return (
       <React.Fragment>
         <Route exact path="/" render={(props) => {
-          return <Auth {...props} setCurrentUser={setCurrentUser} />
+          return !currentUser ? (
+            <Auth {...props} setCurrentUser={setCurrentUser} />
+          ) : (
+              <Redirect to="/vote" />
+            )
         }} />
         <Route path="/vote/" render={(props) => {
-          return <Vote currentUser={this.props.currentUser} {...props} />
+          return currentUser ? (
+            <Vote
+              currentUser={currentUser} {...props}
+              setCurrentUser={setCurrentUser}
+            />
+          ) : (
+              <Redirect to="/" />
+            )
         }} />
         <Route path="/admin" render={(props) => {
           return <AdminViews {...props} />

--- a/src/components/auth/Auth.js
+++ b/src/components/auth/Auth.js
@@ -6,9 +6,10 @@ import Login from './Login';
 /* eslint-disable */
 class Auth extends Component {
   render() {
+    const { setCurrentUser } = this.props;
     return (
       <>
-        <Login />
+        <Login setCurrentUser={setCurrentUser} />
         {/* <Link to="vote/">Vote Now</Link> */}
       </>
     );

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -56,18 +56,17 @@ class Login extends Component {
 
   signIn() {
     const { setCurrentUser } = this.props;
-    let githubCredentials;
     let profileUser;
 
     this.auth.signInWithPopup(this.githubProvider)
-      .then((credentials) => {
-        githubCredentials = credentials;
+      .then((githubCredentials) => {
         const { uid } = githubCredentials.user;
         const userRef = this.db.collection('users').doc(uid);
-        return userRef.get();
-      }).then((userSnapshot) => {
-        if (userSnapshot.exists) return null;
         profileUser = this.builduser(githubCredentials);
+        return userRef.get();
+      })
+      .then((userSnapshot) => {
+        if (userSnapshot.exists) return null;
         return userSnapshot.ref.set(profileUser);
       })
       .then(() => {

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -4,6 +4,7 @@ import { Dropdown, Button } from 'semantic-ui-react';
 import * as firebase from 'firebase/app';
 import 'firebase/firestore';
 import 'firebase/auth';
+import { storeUser } from '../../modules/userManager';
 
 
 class Login extends Component {
@@ -54,7 +55,9 @@ class Login extends Component {
   }
 
   signIn() {
+    const { setCurrentUser } = this.props;
     let githubCredentials;
+    let profileUser;
 
     this.auth.signInWithPopup(this.githubProvider)
       .then((credentials) => {
@@ -63,12 +66,14 @@ class Login extends Component {
         const userRef = this.db.collection('users').doc(uid);
         return userRef.get();
       }).then((userSnapshot) => {
-        if (userSnapshot.exists) return;
-        const user = this.builduser(githubCredentials);
-        userSnapshot.ref.set(user);
+        if (userSnapshot.exists) return null;
+        profileUser = this.builduser(githubCredentials);
+        return userSnapshot.ref.set(profileUser);
       })
       .then(() => {
         const { history } = this.props;
+        storeUser(profileUser);
+        setCurrentUser(profileUser);
         history.push('vote/');
       });
   }

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import {
   Header, Image,
 } from 'semantic-ui-react';
+import { removeUser } from '../../modules/userManager';
 
 class Nav extends Component {
   constructor(props) {
@@ -14,6 +15,8 @@ class Nav extends Component {
       cohort: {},
     };
     this.db = firebase.firestore();
+
+    this.logout = this.logout.bind(this);
   }
 
   componentDidMount() {
@@ -24,6 +27,12 @@ class Nav extends Component {
       });
   }
 
+  logout() {
+    const { setCurrentUser } = this.props;
+    setCurrentUser(null);
+    removeUser();
+  }
+
 
   render() {
     const { cohort } = this.state;
@@ -32,7 +41,13 @@ class Nav extends Component {
         <div className="nav">
           <ul>
             <li>NSS</li>
-            <li><Link to="/">Logout</Link></li>
+            {
+              /* I'm ignoring eslint a11y rules for now
+              because I'm assuming Bryan
+              is going to change the nav */
+            }
+            {/* eslint-disable-next-line */}
+            <li onClick={this.logout}>Logout</li>
             <li><Link to="/vote">Vote</Link></li>
             <li><Link to="/vote/addAward">Add Award</Link></li>
           </ul>

--- a/src/components/vote/Vote.js
+++ b/src/components/vote/Vote.js
@@ -4,9 +4,12 @@ import VoteList from './VoteList';
 import CreateAward from './CreateAward';
 import Nav from '../nav/Nav';
 
-const Vote = ({ currentUser }) => (
+const Vote = ({ currentUser, setCurrentUser }) => (
   <>
-    <Nav currentUser={currentUser} />
+    <Nav
+      currentUser={currentUser}
+      setCurrentUser={setCurrentUser}
+    />
     <Route
       path="/vote/addAward"
       render={props => <CreateAward currentUser={currentUser} {...props} />

--- a/src/modules/userManager.js
+++ b/src/modules/userManager.js
@@ -1,4 +1,5 @@
 export const storeUser = user => localStorage.setItem('user', JSON.stringify(user));
+export const removeUser = () => localStorage.removeItem('user');
 export const getUser = () => {
   const user = localStorage.getItem('user');
   return user ? JSON.parse(user) : null;

--- a/src/modules/userManager.js
+++ b/src/modules/userManager.js
@@ -1,0 +1,5 @@
+export const storeUser = user => localStorage.setItem('user', JSON.stringify(user));
+export const getUser = () => {
+  const user = localStorage.getItem('user');
+  return user ? JSON.parse(user) : null;
+};


### PR DESCRIPTION
This PR copies auth state into local storage instead of relying on Firebase to tell us when the auth state changes. 

PROS: Can store entire user object (github profile and cohort info) locally, whereas before, the application was _always_ making a call to the database to fetch additional user info, even if the user was logged in.

CONS: Duplication of auth state since it now lives in both indexedDB (where firebase puts it) and local storage (where I put it). FWIW I don't have a huge problem with this.

This PR also handles some route protection, rerouting, and logging out.

To test: Log in both and a new and existing user